### PR TITLE
fix(auth): quand le jeton décodé est vide, on jette une erreur

### DIFF
--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -56,7 +56,7 @@ function compareToken ({ token }) {
 
 function enforceToken ({ name }) {
   return async (request, reply) => {
-    if (request[name] === null) {
+    if (!request[name]) {
       return reply.code(401).send({
         error: 'Un jeton d\'API est nécessaire pour accéder à ce contenu.'
       })


### PR DESCRIPTION
Résultante d'un passage à la va-vite vers `fast-jwt`, dont la signature de fonction différait de `jsonwebtoken` (mais ça fonctionnait quand même).

Autre problème, quand un jeton avait expiré, ça ne renvoyait pas d'erreur (but de la fonction `enforceToken()`).

Dernier problème : on resignait un contenu de jeton décode. La présence de `exp` (fixé à 8 minutes) surchargait la validité souhaitée (30 jours).