### PR TITLE
Upload des versions Sentry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,6 +58,36 @@ jobs:
         docker tag agencebio/cartobio-api agencebio/cartobio-api:${{ steps.publish.outputs.tag }}
         docker push agencebio/cartobio-api:${{ steps.publish.outputs.tag }}
 
+  create-sentry:
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Assign sentry environment
+      id: sentry
+      run: |
+        if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
+          echo "environment=staging" >> $GITHUB_OUTPUT
+          echo "version=$(node -p "require('./package.json').version")-dev-${{ github.sha }}" >> $GITHUB_OUTPUT
+        else
+          echo "environment=production" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF_NAME#v*}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create Sentry release
+      uses: getsentry/action-release@v1
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: betagouv
+        SENTRY_PROJECT: cartobio-api
+        SENTRY_URL: https://sentry.incubateur.net/
+        SENTRY_LOG_LEVEL: debug
+      with:
+        environment: ${{ steps.sentry.outputs.environment }}
+        version: ${{ steps.sentry.outputs.version }}
+        # On a pas l'intégration GitHub qui permet que Sentry récupère dans
+        # l'autre sens les commits liés à la release, donc on skip
+        set_commits: skip
+
   deploy-staging:
     needs: [build]
     if: github.ref == 'refs/heads/main'
@@ -76,6 +106,7 @@ jobs:
           && docker run -d --restart unless-stopped \
             -p 127.0.0.1:7500:8000 \
             --env-file=.env.cartobio-api-staging \
+            --env SENTRY_RELEASE=$(node -p "require('./package.json').version")-dev-${{ github.sha }} \
             --add-host=postgres:$(docker inspect -f '{{.NetworkSettings.IPAddress}}' postgres-staging) \
             --name cartobio-api-staging \
             ${{ needs.build.outputs.image }}

--- a/server.js
+++ b/server.js
@@ -43,16 +43,23 @@ const sign = createSigner({ key: config.get('jwtSecret'), expiresIn: DURATION_ON
 
 // Sentry error reporting setup
 if (reportErrors) {
-  Sentry.init({
+  const sentryOptions = {
     dsn: config.get('sentry.dsn'),
     environment: config.get('environment'),
     includeLocalVariables: true,
     integrations: [
       new ExtraErrorData()
     ],
-    release: 'cartobio-api@' + config.get('version'),
     tracesSampleRate: config.get('environment') === 'production' ? 0.2 : 1
-  })
+  }
+
+  if (config.get('environment') === 'production') {
+    sentryOptions.release = config.get('version')
+  } else if (config.get('environment') === 'staging') {
+    sentryOptions.release = process.env.SENTRY_RELEASE
+  }
+
+  Sentry.init(sentryOptions)
 }
 
 app.setErrorHandler(new FastifyErrorHandler({


### PR DESCRIPTION
Upload les versions de sentry (2.*.* pour la production, le sha du commit pour staging).

Par contre je ne sais pas trop quelle est la meilleure approche pour récupérer l'identifiant du commit au runtime pour staging, est-ce que tu aurais une idée d'un truc pas trop compliqué @thom4parisot ?