### PR TITLE
Retourne un niveau de conversion par défaut

### DIFF
--- a/lib/outputs/features.js
+++ b/lib/outputs/features.js
@@ -1,0 +1,33 @@
+const communes = require('../../data/communes-with-centroids.json')
+
+const NIVEAU_C0 = 'CONV'
+const NIVEAU_C1 = 'C1'
+const NIVEAU_C2 = 'C2'
+const NIVEAU_C3 = 'C3'
+const NIVEAU_AB = 'AB'
+
+function populateWithCentroid (feature) {
+  // determine COMMUNE by centroid
+  // way too hungry to enable this
+  // if (!feature.properties.COMMUNE) {
+  //   const { code = '', nom = '' } = communes.find(({ geometry }) => intersects(geometry, feature)) ?? {}
+  //   feature.properties.COMMUNE = code
+  //   feature.properties.COMMUNE_LABEL = nom
+  // }
+
+  // determine COMMUNE label
+  if (feature.properties.COMMUNE && !feature.properties.COMMUNE_LABEL) {
+    feature.properties.COMMUNE_LABEL = communes.find(({ code }) => code === feature.properties.COMMUNE)?.nom ?? ''
+  }
+
+  return feature
+}
+function populateWithConversionNiveau (feature) {
+  if (!feature.properties.conversion_niveau) {
+    feature.properties.conversion_niveau = NIVEAU_C0
+  }
+
+  return feature
+}
+
+module.exports = { populateWithCentroid, populateWithConversionNiveau, NIVEAU_C0, NIVEAU_C1, NIVEAU_C2, NIVEAU_C3, NIVEAU_AB }

--- a/lib/outputs/operator.js
+++ b/lib/outputs/operator.js
@@ -5,7 +5,6 @@
  * @typedef {@import('../providers/agence-bio.d.ts').numeroBio} numeroBio
  */
 
-const communes = require('../../data/communes-with-centroids.json')
 const pool = require('../db.js')
 
 const ALLOWED_PROPERTIES = [
@@ -75,26 +74,4 @@ function populateWithMetadata (operators) {
     })
 }
 
-function populateWithCentroid (featureCollection) {
-  return {
-    ...featureCollection,
-    features: featureCollection.features.map(feature => {
-      // determine COMMUNE by centroid
-      // way too hungry to enable this
-      // if (!feature.properties.COMMUNE) {
-      //   const { code = '', nom = '' } = communes.find(({ geometry }) => intersects(geometry, feature)) ?? {}
-      //   feature.properties.COMMUNE = code
-      //   feature.properties.COMMUNE_LABEL = nom
-      // }
-
-      // determine COMMUNE label
-      if (feature.properties.COMMUNE && !feature.properties.COMMUNE_LABEL) {
-        feature.properties.COMMUNE_LABEL = communes.find(({ code }) => code === feature.properties.COMMUNE)?.nom ?? ''
-      }
-
-      return feature
-    })
-  }
-}
-
-module.exports = { decorate, populateWithCentroid, populateWithMetadata }
+module.exports = { decorate, populateWithMetadata }

--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -5,7 +5,8 @@ const { toWgs84 } = require('reproject')
 
 const pool = require('../db.js')
 const { fetchOperatorById } = require('./agence-bio.js')
-const { populateWithCentroid, populateWithMetadata } = require('../outputs/operator.js')
+const { populateWithMetadata } = require('../outputs/operator.js')
+const { populateWithCentroid, populateWithConversionNiveau } = require('../outputs/features.js')
 
 async function updateOperatorParcels ({ operatorId }, { numeroBio, ocId, ocLabel, geojson, metadata }) {
   const { rows } = await pool.query('SELECT * FROM cartobio_operators WHERE operator_id = $1 LIMIT 1', [operatorId])
@@ -47,7 +48,7 @@ async function addNewOperatorParcel ({ operatorId }, feature) {
 
   const { rows: updatedRows } = await pool.query("UPDATE cartobio_operators set updated_at = now(), parcelles['features'] = (parcelles->'features' || $2::jsonb), audit_history = (audit_history || $3::jsonb) WHERE operator_id = $1 RETURNING record_id, certification_state, audit_history, metadata, parcelles", [
     operatorId,
-    { ...feature, id: newId, properties: { ...feature.properties, id: newId } },
+    populateWithConversionNiveau({ ...feature, id: newId, properties: { ...feature.properties, id: newId } }),
     historyEntry
   ])
 
@@ -67,7 +68,10 @@ async function getOperator ({ operatorId }) {
   const { created_at, record_id, updated_at } = result.rows[0] ?? {}
 
   return {
-    parcelles: parcelles ? populateWithCentroid(parcelles) : featureCollection([]),
+    parcelles: featureCollection(parcelles
+      ? parcelles.features.map(populateWithCentroid).map(populateWithConversionNiveau)
+      : []
+    ),
     metadata: metadata ?? {},
     operator,
     record_id,


### PR DESCRIPTION
Si une parcelle n'est pas engagée, elle est considérée comme en Conventionnel.

Ça évite notamment d'avoir à modifier les parcelles pour dire qu'elles sont en conventionnel, et donc les voir apparaitre dans les exports de données (par exemple, avec Certipaq).