### PR TITLE
Version staging pour Sentry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ jobs:
 
     outputs:
       image: "agencebio/cartobio-api:${{ steps.publish.outputs.tag }}"
+      version: ${{ steps.version.outputs.name }}
 
     steps:
     - uses: actions/checkout@v3
@@ -58,35 +59,9 @@ jobs:
         docker tag agencebio/cartobio-api agencebio/cartobio-api:${{ steps.publish.outputs.tag }}
         docker push agencebio/cartobio-api:${{ steps.publish.outputs.tag }}
 
-  create-sentry:
-    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Assign sentry environment
-      id: sentry
-      run: |
-        if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
-          echo "environment=staging" >> $GITHUB_OUTPUT
-          echo "version=$(node -p "require('./package.json').version")-dev-${{ github.sha }}" >> $GITHUB_OUTPUT
-        else
-          echo "environment=production" >> $GITHUB_OUTPUT
-          echo "version=${GITHUB_REF_NAME#v*}" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Create Sentry release
-      uses: getsentry/action-release@v1
-      env:
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        SENTRY_ORG: betagouv
-        SENTRY_PROJECT: cartobio-api
-        SENTRY_URL: https://sentry.incubateur.net/
-        SENTRY_LOG_LEVEL: debug
-      with:
-        environment: ${{ steps.sentry.outputs.environment }}
-        version: ${{ steps.sentry.outputs.version }}
-        # On a pas l'intégration GitHub qui permet que Sentry récupère dans
-        # l'autre sens les commits liés à la release, donc on skip
-        set_commits: skip
+    - name: Get package.json version
+      id: version
+      run: echo name=$(node -p "require('./package.json').version") >> $GITHUB_OUTPUT
 
   deploy-staging:
     needs: [build]
@@ -106,7 +81,7 @@ jobs:
           && docker run -d --restart unless-stopped \
             -p 127.0.0.1:7500:8000 \
             --env-file=.env.cartobio-api-staging \
-            --env SENTRY_RELEASE=$(node -p "require('./package.json').version")-dev-${{ github.sha }} \
+            --env SENTRY_RELEASE=${{ needs.build.outputs.version }}-dev-${{ github.sha }} \
             --add-host=postgres:$(docker inspect -f '{{.NetworkSettings.IPAddress}}' postgres-staging) \
             --name cartobio-api-staging \
             ${{ needs.build.outputs.image }}


### PR DESCRIPTION
* enlève la publication de la release au moment du build (pas besoin car pas de sourcemap à uploader)
* ajoute correctement le nom de la version pour staging