### PR TITLE
Retourne un Record vide plutôt qu'une 404

### DIFF
--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -69,7 +69,7 @@ function enforceRecord ({ queryFn, fieldId }) {
     const id = request.params[fieldId]
     const record = await queryFn(id)
 
-    if (!record) {
+    if (!record?.record_id) {
       return reply.code(404).send({
         error: 'Parcellaire introuvable'
       })

--- a/lib/middlewares.test.js
+++ b/lib/middlewares.test.js
@@ -26,29 +26,30 @@ describe('enforceRecord()', () => {
       record: null
     }
 
+    const output = { operator: { id: 1 }, metadata: {}, parcelles: featureCollection([]) }
+
     db.query.mockResolvedValue({ rows: [] })
     const hook = enforceRecord({ queryFn: getOperator, fieldId: 'operatorId' })
 
     return hook(request, reply).then(() => {
-      return expect(reply.code).toHaveBeenCalledWith(404)
+      expect(reply.code).toHaveBeenCalledWith(404)
     })
   })
 
-  test('provide a record object when the query is successful', async () => {
-    const record = { record_id: 'abcd', metadata: {}, parcelles: featureCollection([]) }
+  test('known operator and known record', async () => {
     const request = {
       params: { operatorId: 'abcd' },
       record: null
     }
 
+    const record = { record_id: 'abcd', parcelles: featureCollection([]), metadata: { source: 'lol' } }
+    const output = { operator: { id: 1 }, record_id: 'abcd', metadata: { source: 'lol' }, parcelles: featureCollection([]) }
+
     db.query.mockResolvedValue({ rows: [record] })
     const hook = enforceRecord({ queryFn: getOperator, fieldId: 'operatorId' })
 
     return hook(request, reply).then(() => {
-      return expect(request).toHaveProperty('record', {
-        ...record,
-        operator: { id: 1 }
-      })
+      expect(request.record).toMatchObject(output)
     })
   })
 })

--- a/lib/outputs/record.js
+++ b/lib/outputs/record.js
@@ -1,0 +1,23 @@
+const { featureCollection } = require('@turf/helpers')
+const { populateWithCentroid, populateWithMultipleCultures } = require('./features.js')
+
+function normalizeRecord ({ record = null, operator }) {
+  const output = {
+    ...record,
+    metadata: record?.metadata ?? {},
+    operator,
+    parcelles: featureCollection((record?.parcelles?.features ?? [])
+      .map(populateWithCentroid)
+      .map(populateWithMultipleCultures)
+    )
+  }
+
+  delete output.record?.metadata
+  delete output.record?.parcelles
+
+  return output
+}
+
+module.exports = {
+  normalizeRecord
+}

--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -9,7 +9,8 @@ const pool = require('../db.js')
 const config = require('../config.js')
 const { EtatProduction, fetchOperatorById } = require('./agence-bio.js')
 const { populateWithMetadata } = require('../outputs/operator.js')
-const { deepMergeObjects, updateCollectionFeatures, populateWithCentroid, populateWithMultipleCultures } = require('../outputs/features.js')
+const { deepMergeObjects, updateCollectionFeatures } = require('../outputs/features.js')
+const { normalizeRecord } = require('../outputs/record.js')
 const { randomUUID } = require('crypto')
 const { fromCodePacStrict } = require('@agencebio/rosetta-cultures')
 const { CertificationState, EventType, createNewEvent } = require('../history.js')
@@ -46,7 +47,7 @@ async function createOperatorRecord ({ operatorId, decodedToken, record }, { num
   const { state: certificationState } = historyEntry
 
   // in case we delete + imported a data again
-  if (record) {
+  if (record.record_id) {
     const { audit_history: auditHistory } = record
     auditHistory.push(historyEntry)
 
@@ -152,25 +153,17 @@ async function addRecordFeature ({ decodedToken, record }, feature) {
 
 async function getOperator (operatorId) {
   const [result, operator] = await Promise.all([
-    pool.query('SELECT record_id, certification_date_debut, certification_date_fin, certification_state, created_at, updated_at, parcelles, metadata, audit_history, audit_notes, audit_demandes FROM cartobio_operators WHERE operator_id = $1 LIMIT 1', [operatorId]),
+    pool.query(`SELECT ${recordFields} FROM cartobio_operators WHERE operator_id = $1 LIMIT 1`, [operatorId]),
     fetchOperatorById(operatorId)
   ])
 
   const [record] = result.rows
 
-  if (!record) {
+  if (!record && !operator) {
     return null
   }
 
-  return {
-    ...record,
-    operator,
-    metadata: record.metadata ?? {},
-    parcelles: featureCollection(record.parcelles
-      ? record.parcelles.features.map(populateWithCentroid).map(populateWithMultipleCultures)
-      : []
-    )
-  }
+  return normalizeRecord({ record, operator })
 }
 
 async function getRecord (recordId) {
@@ -183,27 +176,7 @@ async function getRecord (recordId) {
 
   const operator = await fetchOperatorById(record.operator_id)
 
-  const { metadata, parcelles } = record
-  /* eslint-disable-next-line camelcase */
-  const { certification_state, audit_history, audit_notes, audit_demandes } = record
-  /* eslint-disable-next-line camelcase */
-  const { created_at, record_id, updated_at } = record
-
-  return {
-    parcelles: featureCollection(parcelles
-      ? parcelles.features.map(populateWithCentroid).map(populateWithMultipleCultures)
-      : []
-    ),
-    metadata: metadata ?? {},
-    operator,
-    record_id,
-    created_at,
-    updated_at,
-    certification_state,
-    audit_history,
-    audit_notes,
-    audit_demandes
-  }
+  return normalizeRecord({ record, operator })
 }
 
 async function deleteRecord ({ decodedToken, record }) {


### PR DESCRIPTION
Sinon on perd des éléments comme les données opérateur… ce qui est nécessaire pour créer un parcellaire.