### PR TITLE
Ajuste l'intérprétation de "après l'audit"

### DIFF
--- a/lib/history.test.js
+++ b/lib/history.test.js
@@ -106,7 +106,7 @@ describe('createNewEvent()', () => {
     expect(createNewEvent(
       EventType.FEATURE_CREATE,
       { features: featureCollection.features, state: CertificationState.OPERATOR_DRAFT },
-      { decodedToken, record: { ...record, certification_state: CertificationState.PENDING_CERTIFICATION } }
+      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject(expectation)
   })
 
@@ -139,7 +139,7 @@ describe('createNewEvent()', () => {
     expect(createNewEvent(
       EventType.FEATURE_CREATE,
       { description: 'test' },
-      { decodedToken, record: { ...record, certification_state: CertificationState.PENDING_CERTIFICATION } }
+      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_CREATE })
 
     // Suppression de parcelle : utilisateur + date
@@ -152,20 +152,20 @@ describe('createNewEvent()', () => {
     expect(createNewEvent(
       EventType.FEATURE_DELETE,
       { description: 'test' },
-      { decodedToken, record: { ...record, certification_state: CertificationState.PENDING_CERTIFICATION } }
+      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_DELETE })
 
     // Terminer l’audit : utilisateur + date
     expect(createNewEvent(
       EventType.CERTIFICATION_STATE_CHANGE,
       { description: 'test', features: featureCollection.features, state: CertificationState.OPERATOR_DRAFT },
-      { decodedToken, record: { ...record, certification_state: CertificationState.PENDING_CERTIFICATION } }
+      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.CERTIFICATION_STATE_CHANGE })
 
     // Envoi du parcellaire pour certification : utilisateur + date
     expect(createNewEvent(
       EventType.CERTIFICATION_STATE_CHANGE,
-      { description: 'test', state: CertificationState.PENDING_CERTIFICATION },
+      { description: 'test', state: CertificationState.AUDITED },
       { decodedToken, record }
     )).toMatchObject({ ...expectation, type: EventType.CERTIFICATION_STATE_CHANGE })
 
@@ -179,7 +179,7 @@ describe('createNewEvent()', () => {
     expect(createNewEvent(
       EventType.FEATURE_COLLECTION_UPDATE,
       { description: 'test', features: featureCollection.features },
-      { decodedToken, record: { ...record, certification_state: CertificationState.PENDING_CERTIFICATION } }
+      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_COLLECTION_UPDATE })
 
     expect(createNewEvent(
@@ -191,14 +191,14 @@ describe('createNewEvent()', () => {
     expect(createNewEvent(
       EventType.FEATURE_UPDATE,
       { description: 'test', features: featureCollection.features },
-      { decodedToken, record: { ...record, certification_state: CertificationState.PENDING_CERTIFICATION } }
+      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_UPDATE })
 
     // Certification du parcellaire : utilisateur + date
     expect(createNewEvent(
       EventType.CERTIFICATION_STATE_CHANGE,
       { description: 'test', features: featureCollection.features, state: CertificationState.CERTIFIED },
-      { decodedToken, record: { ...record, certification_state: CertificationState.PENDING_CERTIFICATION } }
+      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.CERTIFICATION_STATE_CHANGE })
   })
 })


### PR DESCRIPTION
À comprendre comme "tout changement une que le parcellaire a été audité" et non "tout statut de parcellaire suivant celui de l'audit".

Dit autrement, un "supérieur ou égal au statut d'audité" plutôt que "strictement supérieur au statut d'audité".