### PR TITLE
N'importe pas le code précision PAC comme une information de variété

### DIFF
--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -246,9 +246,8 @@ async function pacageLookup ({ numeroPacage }) {
         cultures: [
           {
             id: randomUUID(),
-            CPF: fromCodePacStrict(TYPE)?.code_cpf,
-            TYPE,
-            variete: PRECISION ?? ''
+            CPF: fromCodePacStrict(TYPE/*, PRECISION */)?.code_cpf,
+            TYPE
           }
         ],
         NUMERO_I,

--- a/lib/providers/telepac.js
+++ b/lib/providers/telepac.js
@@ -29,9 +29,8 @@ async function parseShapefileArchive (file) {
         cultures: [
           {
             id: randomUUID(),
-            CPF: fromCodePacStrict(TYPE)?.code_cpf,
-            TYPE,
-            variete: CODE_VAR ?? ''
+            CPF: fromCodePacStrict(TYPE/*, CODE_VAR */)?.code_cpf,
+            TYPE
           }
         ],
         conversion_niveau: AGRIBIO === 1 ? 'AB?' : EtatProduction.NB,


### PR DESCRIPTION
Les retours utilisateurs disent que 001, 003, etc. ne sont pas aidants.