### PR TITLE
Tableau de Bord OC via Numéro Bio

### DIFF
--- a/lib/outputs/operator.js
+++ b/lib/outputs/operator.js
@@ -14,17 +14,17 @@ const pool = require('../db.js')
  * @return {[type]}           The same array, merged with our own local data
  */
 async function populateWithMetadata (operators) {
-  const ids = operators.map(({ id }) => id)
+  const ids = operators.map(({ numeroBio }) => String(numeroBio))
 
   if (ids.length === 0) {
     return operators
   }
 
   return pool
-    .query(`SELECT record_id, created_at, operator_id, certification_state, metadata FROM cartobio_operators WHERE operator_id IN (${ids.join(',')})`)
+    .query('SELECT record_id, created_at, operator_id, numerobio, certification_state, metadata FROM cartobio_operators WHERE numerobio = ANY ($1)', [ids])
     .then(({ rows }) => {
       return operators.map(agenceBioOperatorData => {
-        const { metadata: cartobioOperatorData, ...record } = rows.find(({ operator_id: id }) => id === agenceBioOperatorData.id) || { metadata: {} }
+        const { metadata: cartobioOperatorData, ...record } = rows.find(({ numerobio }) => numerobio === String(agenceBioOperatorData.numeroBio)) || { metadata: {} }
 
         return {
           ...agenceBioOperatorData,

--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -331,11 +331,11 @@ async function pacageLookup ({ numeroPacage }) {
 }
 
 async function fetchLatestCustomersByControlBody ({ ocId }) {
-  const { rows } = await pool.query('SELECT operator_id FROM cartobio_operators WHERE oc_id = $1 ORDER BY updated_at DESC LIMIT 10;', [ocId])
-  const ids = rows.map(({ operator_id: id }) => id).filter(d => d)
+  const { rows } = await pool.query('SELECT numerobio FROM cartobio_operators WHERE oc_id = $1 ORDER BY updated_at DESC LIMIT 10;', [ocId])
+  const ids = rows.map(({ numerobio }) => String(numerobio)).filter(d => d)
 
   const operators = await Promise.allSettled(
-    ids.map(operatorId => fetchOperatorById(operatorId))
+    ids.map(numerobio => fetchOperatorByNumeroBio(numerobio))
   )
     // responses => operators
     // [ [{ status: 'fulfilled', 'value': {...}}}], [{status: 'rejected'}], [{…}] ] => [ {}, {} ]


### PR DESCRIPTION
Sinon, dans le cas d'un import via API, les parcellaires ne figuraient pas dans la liste (la jointure se faisant via `operator_id`, `null`).

