### PR TITLE
Possibilité de réceptionner un parcellaire vide

### DIFF
--- a/lib/providers/agence-bio.js
+++ b/lib/providers/agence-bio.js
@@ -242,8 +242,8 @@ function verifyNotificationAuthorization (authorizationHeader) {
   const token = authorizationHeader.replace(/Bearer /i, '')
 
   try {
-    const payload = verify(token)
-    return { payload, token }
+    const decodedToken = verify(token)
+    return { decodedToken, token }
   } catch (error) {
     return { error }
   }
@@ -325,25 +325,6 @@ async function fetchUserOperators (userId) {
 async function fetchCustomersByOc ({ ocId: oc, numeroBio = '', nom = '' }) {
   const operators = await getOperatorsByOc({ serviceToken, oc, numeroBio, nom })
   return populateWithRecords(operators.map(normalizeOperator))
-}
-
-/**
- * Fetch an operator by its id
- * TODO remove it when this is addressed https://teams.microsoft.com/l/message/19:GfMlZn9iL0RZXQT_27z74_siyraKF8SINSLJRxDDRF41@thread.tacv2/1701690159883?tenantId=87edbd56-3cfc-4d27-a21e-e3aeb99322f6&groupId=ce63eb92-33ef-46e0-821a-e4c7d03f9e0d&parentMessageId=1701690159883&teamName=Cartobio%20%3C%3E%20Improba&channelName=General&createdTime=1701690159883&allowXTenantAccess=false
- * @param {String} operatorId
- * @returns {Promise<AgenceBioNormalizedOperator>}
- */
-async function fetchOperatorById (operatorId) {
-  const token = await auth()
-
-  const data = await get(`${config.get('notifications.endpoint')}/portail/operateur/v2/${operatorId}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Origin
-    }
-  }).json()
-
-  return normalizeOperator(data)
 }
 
 /**
@@ -462,7 +443,6 @@ module.exports = {
   checkOcToken,
   EtatProduction,
   fetchCertificationBody,
-  fetchOperatorById,
   fetchOperatorByNumeroBio,
   fetchUserOperators,
   fetchCustomersByOc,

--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -107,9 +107,9 @@ async function createOrUpdateOperatorRecord (data, context, client) {
     */
     result = await (client || pool).query(
       /* sql */` WITH merged_features AS (
-            SELECT jsonb_agg((SELECT coalesce(old_features, '{}'::jsonb) || new_features - 'properties' || jsonb_build_object(
+            SELECT coalesce(jsonb_agg((SELECT coalesce(old_features, '{}'::jsonb) || new_features - 'properties' || jsonb_build_object(
                 'properties', coalesce(old_features->'properties', '{}'::jsonb) || new_features->'properties')
-            )) AS features
+            )), '[]'::jsonb) AS features
             FROM cartobio_operators, jsonb_array_elements($6::jsonb->'features') AS new_features
             LEFT JOIN jsonb_array_elements(cartobio_operators.parcelles->'features') AS old_features
             ON (new_features->>'id')::bigint = (old_features ->>'id')::bigint
@@ -330,10 +330,10 @@ async function deleteRecord ({ decodedToken, record }) {
   )
 
   const result = await pool.query(/* sql */`UPDATE cartobio_operators
-    SET updated_at = now(), parcelles = NULL, certification_date_debut = NULL, certification_date_fin = NULL, certification_state = NULL, audit_notes = '', metadata = '{}'::jsonb, audit_history = (audit_history || coalesce($2, '[]')::jsonb)
+    SET updated_at = now(), parcelles = $3::jsonb, certification_date_debut = NULL, certification_date_fin = NULL, certification_state = NULL, audit_notes = '', metadata = '{}'::jsonb, audit_history = (audit_history || coalesce($2, '[]')::jsonb)
     WHERE record_id = $1
     RETURNING ${recordFields}`,
-  [record.record_id, historyEntry])
+  [record.record_id, historyEntry, featureCollection([])])
 
   return result.rows.at(0)
 }

--- a/migrations/20231213163820-parcels-not-null.js
+++ b/migrations/20231213163820-parcels-not-null.js
@@ -1,0 +1,28 @@
+'use strict'
+
+var dbm
+var type
+var seed
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+}
+
+exports.up = async function (db) {
+  await db.runSql('UPDATE cartobio_operators SET parcelles = \'{"type": "FeatureCollection", "features": []}\'::jsonb WHERE parcelles IS NULL')
+  return db.runSql('ALTER TABLE "cartobio_operators" ALTER COLUMN "parcelles" SET NOT NULL')
+}
+
+exports.down = function (db) {
+  return null
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/20231213163821-fix-trigger.js
+++ b/migrations/20231213163821-fix-trigger.js
@@ -1,0 +1,72 @@
+'use strict'
+
+let dbm
+let type
+let seed
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+}
+
+exports.up = function (db) {
+  // Add validity check on parcelle geometry
+  db.runSql(
+    /* sql */`
+    CREATE OR REPLACE FUNCTION update_communes() RETURNS trigger AS $$
+    BEGIN
+        NEW.parcelles = jsonb_set(
+            NEW.parcelles,
+            '{features}',
+            (
+                SELECT
+                    coalesce(jsonb_agg(
+                        (
+                            SELECT CASE
+                                WHEN feature.value->'properties'->>'COMMUNE' IS NULL
+                                    AND ST_IsValid(ST_SetSRID(ST_GeomFromGeoJSON(feature.value->>'geometry'), 4326))
+                                THEN
+                                    jsonb_set(
+                                        feature.value,
+                                        '{properties}',
+                                        feature.value->'properties' || jsonb_build_object(
+                                            'COMMUNE',
+                                            (
+                                                SELECT code
+                                                FROM communes
+                                                WHERE ST_Intersects(
+                                                    ST_SetSRID(ST_GeomFromGeoJSON(feature.value->>'geometry'), 4326),
+                                                    geometry
+                                                ) LIMIT 1
+                                            )::text
+                                        ),
+                                        true
+                                    )
+                                ELSE
+                                    feature.value
+                                END
+                        )
+                    ), '[]'::jsonb)
+                FROM jsonb_array_elements(NEW.parcelles->'features') AS feature
+            )
+        );
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `)
+
+  return null
+}
+
+exports.down = function (db) {
+  return null
+}
+
+exports._meta = {
+  version: 1
+}


### PR DESCRIPTION
Authorise la fonctionnalité "Créer un parcellaire de zéro".

Idéalement, on ne voudrait autoriser ce cas d'appel que si les métadonnées sont vides, et qu'on est en statut `OPERATOR_DRAFT`. Pour éviter qu'un parcellaire soit détruit par le biais d'une attaque.

refs AgenceBio/cartobio-front#273