### PR TITLE
Refactor : create a user type distinct from decodedToken

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -88,11 +88,11 @@ function shouldCreateHistoryEvent ({ record, eventType }) {
  * @param {Feature[]} [payload.features]
  * @param {String} [payload.date]
  * @param {Object} [event]
- * @param {{ decodedToken: DecodedToken, record: DBOperatorRecord }} context
+ * @param {{ user: AgenceBioUser, record: DBOperatorRecord|null }} context
  * @returns {HistoryEntry|null}
  */
-function createNewEvent (eventType, { description, features, state, date, ...event }, { decodedToken, record }) {
-  if (!record || !decodedToken || shouldCreateHistoryEvent({ record, eventType })) {
+function createNewEvent (eventType, { description, features, state, date, ...event }, { user, record }) {
+  if (!record || !user || shouldCreateHistoryEvent({ record, eventType })) {
     return {
       ...event,
       type: eventType,
@@ -100,16 +100,7 @@ function createNewEvent (eventType, { description, features, state, date, ...eve
       ...(state ? { state } : {}),
       ...(features ? { featureIds: collectFeatureIdsFromPayload(features) } : {}),
       date: (date || new Date()).toISOString(),
-      ...(decodedToken
-        ? {
-            user: {
-              id: decodedToken.id,
-              nom: `${decodedToken.prenom ?? ''} ${decodedToken.nom ?? ''}`.trim(),
-              organismeCertificateur: decodedToken.organismeCertificateur,
-              mainGroup: decodedToken.mainGroup
-            }
-          }
-        : {})
+      ...(user ? { user } : {})
     }
   }
 

--- a/lib/history.test.js
+++ b/lib/history.test.js
@@ -25,7 +25,10 @@ describe('collectFeatureIdsFromPayload()', () => {
 })
 
 describe('createNewEvent()', () => {
-  const decodedToken = {
+  /**
+   * @type {AgenceBioUser}
+   */
+  const user = {
     nom: 'test',
     id: 1,
     mainGroup: { nom: 'Opérateur' },
@@ -55,6 +58,9 @@ describe('createNewEvent()', () => {
     ]
   }
 
+  /**
+   * @type {DBOperatorRecord}
+   */
   const record = {
     record_id: 'aaa-bbb-ccc-dddd',
     certification_state: CertificationState.OPERATOR_DRAFT,
@@ -68,7 +74,7 @@ describe('createNewEvent()', () => {
       state: CertificationState.OPERATOR_DRAFT,
       featureIds: ['1234', '5678'],
       user: {
-        ...decodedToken,
+        ...user,
         nom: 'test'
       }
     }
@@ -76,13 +82,13 @@ describe('createNewEvent()', () => {
     expect(createNewEvent(
       EventType.FEATURE_COLLECTION_CREATE,
       { features: featureCollection, state: CertificationState.OPERATOR_DRAFT },
-      { decodedToken, record: null }
+      { user, record: null }
     )).toMatchObject(expectation)
 
     expect(createNewEvent(
       EventType.FEATURE_COLLECTION_CREATE,
       { features: featureCollection.features, state: CertificationState.OPERATOR_DRAFT },
-      { decodedToken, record }
+      { user, record }
     )).toMatchObject(expectation)
   })
 
@@ -92,7 +98,7 @@ describe('createNewEvent()', () => {
       state: CertificationState.OPERATOR_DRAFT,
       featureIds: ['1234', '5678'],
       user: {
-        ...decodedToken,
+        ...user,
         nom: 'test'
       }
     }
@@ -100,13 +106,13 @@ describe('createNewEvent()', () => {
     expect(createNewEvent(
       EventType.FEATURE_CREATE,
       { features: featureCollection.features, state: CertificationState.OPERATOR_DRAFT },
-      { decodedToken, record }
+      { user, record }
     )).toBeNull()
 
     expect(createNewEvent(
       EventType.FEATURE_CREATE,
       { features: featureCollection.features, state: CertificationState.OPERATOR_DRAFT },
-      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
+      { user, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject(expectation)
   })
 
@@ -116,7 +122,7 @@ describe('createNewEvent()', () => {
       type: null,
       description: 'test',
       user: {
-        ...decodedToken,
+        ...user,
         nom: 'test'
       }
     }
@@ -125,80 +131,80 @@ describe('createNewEvent()', () => {
     expect(createNewEvent(
       EventType.FEATURE_COLLECTION_CREATE,
       { description: 'test' },
-      { decodedToken, record }
+      { user, record }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_COLLECTION_CREATE })
 
     // Suppression du parcellaire : utilisateur + date
     expect(createNewEvent(
       EventType.FEATURE_COLLECTION_DELETE,
       { description: 'test' },
-      { decodedToken, record }
+      { user, record }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_COLLECTION_DELETE })
 
     // Ajout de parcelle : utilisateur + date
     expect(createNewEvent(
       EventType.FEATURE_CREATE,
       { description: 'test' },
-      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
+      { user, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_CREATE })
 
     // Suppression de parcelle : utilisateur + date
     expect(createNewEvent(
       EventType.FEATURE_DELETE,
       { description: 'test' },
-      { decodedToken, record }
+      { user, record }
     )).toBeNull()
 
     expect(createNewEvent(
       EventType.FEATURE_DELETE,
       { description: 'test' },
-      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
+      { user, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_DELETE })
 
     // Terminer l’audit : utilisateur + date
     expect(createNewEvent(
       EventType.CERTIFICATION_STATE_CHANGE,
       { description: 'test', features: featureCollection.features, state: CertificationState.OPERATOR_DRAFT },
-      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
+      { user, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.CERTIFICATION_STATE_CHANGE })
 
     // Envoi du parcellaire pour certification : utilisateur + date
     expect(createNewEvent(
       EventType.CERTIFICATION_STATE_CHANGE,
       { description: 'test', state: CertificationState.AUDITED },
-      { decodedToken, record }
+      { user, record }
     )).toMatchObject({ ...expectation, type: EventType.CERTIFICATION_STATE_CHANGE })
 
     // Changement sur le parcellaire : modification de culture, date d’engagement, statut de conversion : utilisateur + date
     expect(createNewEvent(
       EventType.FEATURE_COLLECTION_UPDATE,
       { description: 'test', features: featureCollection.features },
-      { decodedToken, record }
+      { user, record }
     )).toBeNull()
 
     expect(createNewEvent(
       EventType.FEATURE_COLLECTION_UPDATE,
       { description: 'test', features: featureCollection.features },
-      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
+      { user, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_COLLECTION_UPDATE })
 
     expect(createNewEvent(
       EventType.FEATURE_UPDATE,
       { description: 'test', features: featureCollection.features },
-      { decodedToken, record }
+      { user, record }
     )).toBeNull()
 
     expect(createNewEvent(
       EventType.FEATURE_UPDATE,
       { description: 'test', features: featureCollection.features },
-      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
+      { user, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.FEATURE_UPDATE })
 
     // Certification du parcellaire : utilisateur + date
     expect(createNewEvent(
       EventType.CERTIFICATION_STATE_CHANGE,
       { description: 'test', features: featureCollection.features, state: CertificationState.CERTIFIED },
-      { decodedToken, record: { ...record, certification_state: CertificationState.AUDITED } }
+      { user, record: { ...record, certification_state: CertificationState.AUDITED } }
     )).toMatchObject({ ...expectation, type: EventType.CERTIFICATION_STATE_CHANGE })
   })
 })

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -17,7 +17,7 @@ const { UnauthorizedApiError, InvalidRequestApiError, NotFoundApiError } = requi
  * @param {String[]} keys - keys property on the token
  * @return {onRequestHookHandler}
  */
-function decodeToken ({ keys }) {
+function decodeUserToken ({ keys }) {
   // fast-jwt documentation states that
   // > When enabled (…) performances dramatically improve.
   // So we enable cache.
@@ -36,7 +36,10 @@ function decodeToken ({ keys }) {
       // We cycle through various verification methods until one succeeds
       // For example, a Bearer emitted by CartoBio could fail
       // whereas a Notification token via Public Key could be okay
-      request.decodedToken = await Promise
+      /**
+       * @type {AgenceBioUser}
+       */
+      request.user = await Promise
         .allSettled(verifiers.map(fn => fn(token)))
         .then(results => results.find(({ status }) => status === 'fulfilled')?.value)
     } catch (error) {
@@ -115,15 +118,11 @@ function enforceRecord ({ queryFn, param }) {
 
     // Finally, assign the fetched record to forthcoming hooks
     request.record = record
-    // TODO: very hacky, but legacy assumes 1 user -> 1 oc (because 1 user used to be 1 operator)
-    if (request.decodedToken && !request.decodedToken?.organismeCertificateur?.id) {
-      request.decodedToken.organismeCertificateur = record.operator.organismeCertificateur
-    }
   }
 }
 
 /**
- * Compares if the upcoming output organismeCertificateur.id matches the token-provided organismeCertificateur.id
+ * Compares if the upcoming output organismeCertificateur.id matches the user-provided organismeCertificateur.id
  * If it does not work, it prevents the reply to be sent.
  *
  * TODO: because we now fetch the OperatorRecord prior to running the route,
@@ -149,7 +148,7 @@ function compareOperatorOutputAndToken ({ name }) {
 module.exports = {
   compareOperatorOutputAndToken,
   compareToken,
-  decodeToken,
+  decodeUserToken,
   enforceAnyFastifyDecorator,
   enforceRecord,
   verifyAgenceBioToken

--- a/lib/providers/__fixtures__/decoded-token-oc.json
+++ b/lib/providers/__fixtures__/decoded-token-oc.json
@@ -15,5 +15,9 @@
       "id": 2,
       "nom": "Chargé de certification"
     }
-  ]
+  ],
+  "mainGroup": {
+    "id": 1,
+    "nom": "Auditeur"
+  }
 }

--- a/lib/providers/agence-bio.js
+++ b/lib/providers/agence-bio.js
@@ -81,7 +81,7 @@ const { populateWithRecords, normalizeOperator } = require('../outputs/operator.
  * @property {String} status
  * @property {String=} url
  * @property {AgenceBioActivity[]} activites
- * @property {AgenceBioUserProduction[]} productions
+ * @property {AgenceBioProduction[]} productions
  */
 
 /**
@@ -118,14 +118,18 @@ const { populateWithRecords, normalizeOperator } = require('../outputs/operator.
  */
 
 /**
- * User as returned by Agence Bio SSO or API
- * @typedef {Object} AgenceBioOCUser
+ * User as returned by Agence Bio SSO or API and used internally in Cartobio
+ * @typedef {Object} AgenceBioUser
  * @property {Number} id
  * @property {String} prenom
  * @property {String} nom
- * @property {OrganismeCertificateur} organismeCertificateur
  * @property {AgenceBioUserGroup[]} groups
  * @property {AgenceBioUserGroup} mainGroup
+ */
+
+/**
+ * @typedef {AgenceBioUser} AgenceBioOCUser
+ * @property {OrganismeCertificateur} organismeCertificateur
  */
 
 const config = require('../config.js')
@@ -136,8 +140,6 @@ const decode = createDecoder()
 const verify = createVerifier({ key: config.get('notifications.publicKey') })
 
 const ONE_HOUR = 60 * 60 * 1000
-// const ONE_MINUTE = 60 * 1000
-const ACTIVITE_PRODUCTION = 1
 
 /**
  * Authenticate a user based on environment variables
@@ -189,7 +191,7 @@ const fetchCertificationBody = memo(
  *
  * @param userId
  * @param token
- * @returns {Promise<AgenceBioOCUser>}
+ * @returns {Promise<AgenceBioUser>}
  */
 async function getUserProfileById (userId, token = null) {
   const [userProfile, OCs] = await Promise.all([
@@ -222,7 +224,7 @@ async function getUserProfileById (userId, token = null) {
 
 /**
  * @param accessToken
- * @returns {Promise<AgenceBioOCUser>}
+ * @returns {Promise<AgenceBioUser>}
  */
 async function getUserProfileFromSSOToken (accessToken) {
   const decodedToken = decode(accessToken)
@@ -250,35 +252,13 @@ function verifyNotificationAuthorization (authorizationHeader) {
 }
 
 /**
- * Returns operators matching a query
- * @param q
- * @returns {Promise<AgenceBioNormalizedOperator>}
- */
-async function operatorLookup ({ q }) {
-  const token = await auth()
-  const activites = ACTIVITE_PRODUCTION
-  const headers = {
-    Origin,
-    Authorization: `Bearer ${token}`
-  }
-
-  /** @type {Array.<AgenceBioOperator>} */
-  const { items } = await get(`${config.get('notifications.endpoint')}/api/operateurs`, {
-    headers,
-    searchParams: { q, activites, nb: 30 }
-  }).json()
-
-  return items.map(normalizeOperator)
-}
-
-/**
  * Returns operators related to an OC, and eventual filters (numeroBio, or pacage)
  *
- * @param {{serviceToken: string, oc: number, numeroBio: number?, pacage: string?, nom: string?}} params
- * @returns {Promise<AgenceBioOperator>}
+ * @param {{serviceToken: string, oc: number, numeroBio: string?, pacage: string?, nom: string?}} params
+ * @returns {Promise<AgenceBioNormalizedOperator>}
  */
-function _getOperatorsByOc ({ serviceToken, oc, numeroBio = '', pacage = '', nom = '' }) {
-  return get(`${config.get('notifications.endpoint')}/api/getOperatorsByOc`, {
+async function _getOperatorsByOc ({ serviceToken, oc, numeroBio = '', pacage = '', nom = '' }) {
+  const data = await get(`${config.get('notifications.endpoint')}/api/getOperatorsByOc`, {
     headers: {
       Authorization: serviceToken,
       Origin
@@ -291,14 +271,15 @@ function _getOperatorsByOc ({ serviceToken, oc, numeroBio = '', pacage = '', nom
       includeAdresses: 1
     }
   }).json()
-    .then(data => data.map(normalizeOperator))
+
+  return data.map(normalizeOperator)
 }
 
 /**
  * Returns operators related to an OC, and eventual filters (numeroBio, or pacage)
  *
- * @param {{token: string, oc: number, numeroBio: number?, pacage: string?}} params
- * @returns {Promise<AgenceBioOperator>}
+ * @param {{serviceToken: string, oc: number, numeroBio: string?, pacage: string?, nom: string?}} params
+ * @returns {Promise<AgenceBioNormalizedOperator>}
  */
 const getOperatorsByOc = memo(_getOperatorsByOc, {
   maxAge: 12 * ONE_HOUR,
@@ -308,7 +289,7 @@ const getOperatorsByOc = memo(_getOperatorsByOc, {
 /**
  * Returns operators for a given user
  * @param userId
- * @return {Promise<*>}
+ * @return {Promise<AgenceBioNormalizedOperator>}
  */
 async function fetchUserOperators (userId) {
   const { items } = await get(`${config.get('notifications.endpoint')}/api/utilisateur/${userId}/operateurs`, {
@@ -320,7 +301,7 @@ async function fetchUserOperators (userId) {
 
 /**
  * @param  {{numeroBio: number?, ocId: number, nom: string?}}
- * @returns {Promise<AgenceBioNormalizedOperator[]>}
+ * @returns {Promise<NormalizedRecord[]>}
  */
 async function fetchCustomersByOc ({ ocId: oc, numeroBio = '', nom = '' }) {
   const operators = await getOperatorsByOc({ serviceToken, oc, numeroBio, nom })
@@ -448,7 +429,6 @@ module.exports = {
   fetchCustomersByOc,
   getUserProfileById,
   getUserProfileFromSSOToken,
-  operatorLookup,
   normalizeEtatProduction,
   parsePacDetailsFromComment,
   verifyNotificationAuthorization

--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -28,8 +28,6 @@ const ONE_HOUR = 60 * 60 * 1000
  * @typedef {import('geojson').Polygon} Polygon
  * @typedef {import('../history.js').HistoryEntry} HistoryEntry
  *
- * A decoded JWT attached to a request, either an operator or an Agence Bio SSO user
- * @typedef {AgenceBioOperator | AgenceBioOCUser} DecodedToken
  */
 
 /**
@@ -52,8 +50,6 @@ const ONE_HOUR = 60 * 60 * 1000
 
 /* eslint-disable-next-line quotes */
 const recordFields = /* sqlFragment */`record_id, numerobio, certification_date_debut, certification_date_fin, certification_state, created_at, updated_at, parcelles, metadata, audit_history, audit_notes, audit_demandes`
-/* eslint-disable-next-line quotes */
-const partialRecordFields = /* sqlFragment */`certification_state, created_at, numerobio, metadata, record_id, updated_at`
 
 /**
  * Create a new record unless we find a dangling one with the same numeroBio, in which case we update it
@@ -67,14 +63,14 @@ const partialRecordFields = /* sqlFragment */`certification_state, created_at, n
  * @param {import('@turf/helpers').FeatureCollection} data.geojson
  * @param {String} [data.certificationState]
  * @param {Object} [context]
- * @param {DecodedToken} [context.decodedToken]
+ * @param {AgenceBioUser} [context.user]
  * @param {DBOperatorRecord} [context.oldRecord]
  * @param {Date} [context.date]
- * @param {import('pg').Client} [client]
+ * @param {import('pg').ClientBase} [client]
  * @returns {Promise<DBOperatorRecord>}
  */
 async function createOrUpdateOperatorRecord (data, context, client) {
-  const { decodedToken, oldRecord } = context || {}
+  const { user, oldRecord } = context || {}
   const { numeroBio, ocId, ocLabel, metadata, geojson } = data
 
   const certificationState = data.certificationState || CertificationState.OPERATOR_DRAFT
@@ -83,7 +79,7 @@ async function createOrUpdateOperatorRecord (data, context, client) {
   const historyEntry = createNewEvent(
     EventType.FEATURE_COLLECTION_CREATE,
     { features: geojson.features, state: certificationState, metadata, date: context.date },
-    { decodedToken, record: oldRecord }
+    { user, record: oldRecord }
   )
 
   let result = null
@@ -153,15 +149,15 @@ async function createOrUpdateOperatorRecord (data, context, client) {
 }
 
 /**
- * @param {{ decodedToken: DecodedToken, record: DBOperatorRecord }}
+ * @param {{ user: AgenceBioUser, record: DBOperatorRecord }}
  * @param {Feature[]} features
  * @returns {Promise<DBOperatorRecord>}
  */
-async function patchFeatureCollection ({ decodedToken, record }, features) {
+async function patchFeatureCollection ({ user, record }, features) {
   const historyEntry = createNewEvent(
     EventType.FEATURE_COLLECTION_UPDATE,
     { features },
-    { decodedToken, record }
+    { user, record }
   )
 
   const parcelles = updateCollectionFeatures(record.parcelles, features)
@@ -177,13 +173,13 @@ async function patchFeatureCollection ({ decodedToken, record }, features) {
 
 /**
  * @param {Number} featureId
- * @param {DecodedToken} decodedToken
+ * @param {AgenceBioUser} user
  * @param {DBOperatorRecord} record
  * @param {FeatureProperties} properties
  * @param {Polygon} geometry
  * @returns {Promise<DBOperatorRecord>}
  */
-async function updateFeature ({ featureId, decodedToken, record }, { properties, geometry }) {
+async function updateFeature ({ featureId, user, record }, { properties, geometry }) {
   const matchingFeature = record.parcelles.features.find(({ id }) => id === featureId)
 
   if (!matchingFeature) {
@@ -193,7 +189,7 @@ async function updateFeature ({ featureId, decodedToken, record }, { properties,
   const historyEntry = createNewEvent(
     EventType.FEATURE_UPDATE,
     { features: [matchingFeature] },
-    { decodedToken, record }
+    { user, record }
   )
 
   const updatedFeature = {
@@ -220,14 +216,14 @@ async function updateFeature ({ featureId, decodedToken, record }, { properties,
 
 /**
  * @param {Number} featureId
- * @param {DecodedToken} decodedToken
+ * @param {AgenceBioUser} user
  * @param {DBOperatorRecord} record
  * @param {Object} reason
  * @param {String} reason.code
  * @param {String} [reason.details]
  * @returns {Promise<DBOperatorRecord>}
  */
-async function deleteSingleFeature ({ featureId, decodedToken, record }, { reason }) {
+async function deleteSingleFeature ({ featureId, user, record }, { reason }) {
   const matchingFeature = record.parcelles.features.find(({ id }) => id === featureId)
 
   if (!matchingFeature) {
@@ -237,7 +233,7 @@ async function deleteSingleFeature ({ featureId, decodedToken, record }, { reaso
   const historyEntry = createNewEvent(
     EventType.FEATURE_DELETE,
     { features: [matchingFeature], metadata: { reason, feature: matchingFeature } },
-    { decodedToken, record }
+    { user, record }
   )
 
   const parcelles = featureCollection(record.parcelles.features.filter(({ id }) => id !== featureId))
@@ -256,19 +252,19 @@ async function deleteSingleFeature ({ featureId, decodedToken, record }, { reaso
 }
 
 /**
- * @param {DecodedToken} decodedToken
+ * @param {AgenceBioUser} user
  * @param {DBOperatorRecord} record
  * @param {Feature} feature
  * @return {Promise<DBOperatorRecord>}
  */
-async function addRecordFeature ({ decodedToken, record }, feature) {
+async function addRecordFeature ({ user, record }, feature) {
   const newId = Date.now()
 
   /** @type {HistoryEntry} */
   const historyEntry = createNewEvent(
     EventType.FEATURE_CREATE,
     { features: [feature], description: `Parcelle ${feature.properties.cadastre} ajoutée` },
-    { decodedToken, record }
+    { user, record }
   )
 
   const { rows: updatedRows } = await pool.query(/* sql */`UPDATE cartobio_operators
@@ -284,6 +280,10 @@ async function addRecordFeature ({ decodedToken, record }, feature) {
   return updatedRows.at(0)
 }
 
+/**
+ * @param {String} numeroBio
+ * @return {Promise<NormalizedRecord>}
+ */
 async function getOperatorByNumeroBio (numeroBio) {
   const [result, operator] = await Promise.allSettled([
     pool.query(`SELECT ${recordFields} FROM cartobio_operators WHERE numerobio = $1 LIMIT 1`, [numeroBio]),
@@ -317,16 +317,16 @@ async function getRecord (recordId) {
 }
 
 /**
- * @param {DecodedToken} decodedToken
+ * @param {AgenceBioUser} user
  * @param {DBOperatorRecord} record
  * @return {Promise<DBOperatorRecord>}
  */
-async function deleteRecord ({ decodedToken, record }) {
+async function deleteRecord ({ user, record }) {
   /** @type {HistoryEntry} */
   const historyEntry = createNewEvent(
     EventType.FEATURE_COLLECTION_DELETE,
     { },
-    { decodedToken, record }
+    { user, record }
   )
 
   const result = await pool.query(/* sql */`UPDATE cartobio_operators
@@ -346,7 +346,7 @@ async function pacageLookup ({ numeroPacage }) {
   const { rows } = await pool.query('SELECT ST_AsGeoJSON(geom, 15)::json AS geometry, num_ilot as "NUMERO_I", num_parcel as "NUMERO_P", bio as "BIO", code_cultu AS "TYPE", precision AS "PRECISION", fid FROM rpg_bio WHERE pacage = $1', [numeroPacage])
   return toWgs84({
     type: 'FeatureCollection',
-    features: rows.map(({ geometry, fid: id, NUMERO_I, NUMERO_P, PRECISION, TYPE, BIO }) => ({
+    features: rows.map(({ geometry, fid: id, NUMERO_I, NUMERO_P, TYPE, BIO }) => ({
       type: 'Feature',
       id,
       remoteId: id,
@@ -397,7 +397,7 @@ async function fetchLatestCustomersByControlBody ({ ocId }) {
 }
 
 /**
- * @param {DecodedToken} decodedToken
+ * @param {AgenceBioUser} user
  * @param {DBOperatorRecord} record
  * @param {Object} patch
  * @param {String} patch.auditeur_notes
@@ -410,10 +410,13 @@ async function fetchLatestCustomersByControlBody ({ ocId }) {
  * @param {String} patch.engagement_date
  * @return {Promise<DBOperatorRecord>}
  */
-async function updateAuditRecordState ({ decodedToken, record }, patch) {
+async function updateAuditRecordState ({ user, record }, patch) {
   const { certification_state: state } = patch
   const columns = ['updated_at']
   const placeholders = ['$2']
+  /**
+   * @type {*[]}
+   */
   const values = ['NOW()']
 
   Object.entries(patch).forEach(([field, value]) => {
@@ -428,7 +431,7 @@ async function updateAuditRecordState ({ decodedToken, record }, patch) {
     values.push(createNewEvent(
       EventType.CERTIFICATION_STATE_CHANGE,
       { state },
-      { decodedToken, record }
+      { user, record }
     ))
   }
 

--- a/lib/providers/cartobio.test.js
+++ b/lib/providers/cartobio.test.js
@@ -4,7 +4,7 @@ const { TimeoutError } = require('got')
 const pool = require('../db.js')
 const { NotFoundApiError } = require('../errors.js')
 const record = require('./__fixtures__/record-with-features.json')
-const decodedToken = require('./__fixtures__/decoded-token-oc.json')
+const user = require('./__fixtures__/decoded-token-oc.json')
 const { parseAPIParcellaireStream } = require('./cartobio.js')
 const { createReadStream } = require('fs')
 const { join } = require('path')
@@ -66,11 +66,11 @@ describe('deleteSingleFeature', () => {
 
     pool.query.mockResolvedValueOnce({ rows: [expectation] })
 
-    return expect(deleteSingleFeature({ featureId, record, decodedToken }, { reason })).resolves.toEqual(expectation)
+    return expect(deleteSingleFeature({ featureId, record, user }, { reason })).resolves.toEqual(expectation)
   })
 
   test('throws an error when trying to remove a non-existing feature', () => {
-    return expect(deleteSingleFeature({ featureId: 9999, record, decodedToken }, { reason })).rejects.toThrow(NotFoundApiError)
+    return expect(deleteSingleFeature({ featureId: 9999, record, user }, { reason })).rejects.toThrow(NotFoundApiError)
   })
 })
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { decodeToken, enforceRecord, verifyAgenceBioToken, enforceAnyFastifyDecorator, compareToken, compareOperatorOutputAndToken } = require('../middlewares.js')
+const { decodeUserToken, enforceRecord, verifyAgenceBioToken, enforceAnyFastifyDecorator, compareToken, compareOperatorOutputAndToken } = require('../middlewares.js')
 const { getOperatorByNumeroBio, getRecord } = require('../providers/cartobio.js')
 const config = require('../config.js')
 const host = config.get('host')
@@ -157,10 +157,10 @@ function protectedWithToken ({ oc = false, cartobio = true, mattermost = false }
   }
 
   if (cartobio) {
-    requiredDecorators.push('decodedToken')
+    requiredDecorators.push('user')
     root.schema.tags.push(TAGS.CARTOBIO)
     root.schema.security.push({ bearerAuth: [] })
-    root.onRequest.push(decodeToken({
+    root.onRequest.push(decodeUserToken({
       keys: [
         // this one if for the tokens we emit with this application
         config.get('jwtSecret'),
@@ -188,11 +188,11 @@ function protectedWithToken ({ oc = false, cartobio = true, mattermost = false }
 
 const enforceSameCertificationBody = {
   onRequest: [
-    decodeToken({ keys: [config.get('jwtSecret')] })
+    decodeUserToken({ keys: [config.get('jwtSecret')] })
   ],
 
   preSerialization: [
-    compareOperatorOutputAndToken({ name: 'decodedToken' })
+    compareOperatorOutputAndToken({ name: 'user' })
   ]
 }
 


### PR DESCRIPTION
Finalement, le changement principal consiste à s'assurer qu'on utilise le même type JSDoc pour :

* l'objet utilisateur retourné par le SSO ou l'API AgenceBio au moment de la connexion
* l'objet user (et plus decodedToken) attaché à la requête et récupéré depuis le token JWT par la suite