### PR TITLE
fix: use type NormalizedRecord

### DIFF
--- a/lib/outputs/history.js
+++ b/lib/outputs/history.js
@@ -1,7 +1,8 @@
 /**
  * @typedef {import('../providers/types/cartobio').CartoBioUser} CartoBioUser
  * @typedef {import('../providers/types/cartobio').DBOperatorRecord} DBOperatorRecord
- * @typedef {import('./types/features.js').CartoBioFeature} CartoBioFeature
+ * @typedef {import('./types/features').CartoBioFeature} CartoBioFeature
+ * @typedef {import('./types/record').NormalizedRecord} NormalizedRecord
  *
  */
 
@@ -51,7 +52,7 @@ function isAfterCertificationState (referenceState) {
 const hasBeenAudited = isAfterCertificationState(CertificationState.AUDITED)
 
 /**
- * @type {Array<(event: {eventType: EventType, record: DBOperatorRecord}) => boolean>}
+ * @type {Array<(event: {eventType: EventType, record: NormalizedRecord}) => boolean>}
  */
 const EventTypeRules = [
   // [*] Import/création du parcellaire
@@ -74,7 +75,7 @@ const EventTypeRules = [
 /**
  * Determine if a new HistoryEntry should be created
  * @param {Object} params
- * @param {DBOperatorRecord} params.record - the previous state of operator record
+ * @param {NormalizedRecord} params.record - the previous state of operator record
  * @param {EventType} params.eventType - the type of event
  * @returns {boolean} - true if a new HistoryEntry should be created
  */
@@ -93,7 +94,7 @@ function shouldCreateHistoryEvent ({ record, eventType }) {
  * @param {Date} [payload.date]
  * @param {Object} context
  * @param {CartoBioUser} context.user
- * @param {DBOperatorRecord|null} context.record
+ * @param {NormalizedRecord|null} context.record
  * @returns {HistoryEntry|null}
  */
 function createNewEvent (eventType, payload, { user, record }) {

--- a/lib/outputs/record.js
+++ b/lib/outputs/record.js
@@ -5,12 +5,7 @@ const { populateWithCommunesLabels, populateWithMultipleCultures } = require('./
  * @typedef {import('../providers/types/agence-bio').AgenceBioOperator} AgenceBioOperator
  * @typedef {import('../providers/types/cartobio').DBOperatorRecord} DBOperatorRecord
  * @typedef {import('./types/operator').AgenceBioNormalizedOperator} AgenceBioNormalizedOperator
- */
-
-/**
- * A database record normalized to be used in Cartobio, with operator data from Agence Bio
- * @typedef {DBOperatorRecord} NormalizedRecord
- * @property {AgenceBioNormalizedOperator=} operator
+ * @typedef {import('./types/record').NormalizedRecord} NormalizedRecord
  */
 
 /**

--- a/lib/outputs/types/features.d.ts
+++ b/lib/outputs/types/features.d.ts
@@ -15,7 +15,7 @@ export type CartoBioFeatureProperties = GeoJsonProperties & {
     PACAGE?: string;
     NUMERO_I?: string;
     NUMERO_P?: string;
-    cadastre?: string;
+    cadastre?: string[];
     /**
      * @deprecated
      */

--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -50,7 +50,7 @@ const recordFields = /* sqlFragment */`record_id, numerobio, certification_date_
  * @param {String} [data.certificationState]
  * @param {Object} [context]
  * @param {CartoBioUser} [context.user]
- * @param {DBOperatorRecord} [context.oldRecord]
+ * @param {NormalizedRecord} [context.oldRecord]
  * @param {Date} [context.date]
  * @param {import('pg').ClientBase} [client]
  * @returns {Promise<DBOperatorRecord>}
@@ -110,7 +110,7 @@ async function createOrUpdateOperatorRecord (data, context, client) {
 /**
  * @param {Object} recordInfo
  * @param {CartoBioUser} recordInfo.user
- * @param {DBOperatorRecord} recordInfo.record
+ * @param {NormalizedRecord} recordInfo.record
  * @param {CartoBioFeature[]} features
  * @returns {Promise<DBOperatorRecord>}
  */
@@ -136,7 +136,7 @@ async function patchFeatureCollection ({ user, record }, features) {
  * @param {Object} featureInfo
  * @param {Number} featureInfo.featureId
  * @param {CartoBioUser} featureInfo.user
- * @param {DBOperatorRecord} featureInfo.record
+ * @param {NormalizedRecord} featureInfo.record
  * @param {Object} featureData
  * @param {CartoBioFeatureProperties} featureData.properties
  * @param {Polygon} featureData.geometry
@@ -180,7 +180,7 @@ async function updateFeature ({ featureId, user, record }, { properties, geometr
  * @param {Object} updated
  * @param {Number} updated.featureId
  * @param {CartoBioUser} updated.user
- * @param {DBOperatorRecord} updated.record
+ * @param {NormalizedRecord} updated.record
  * @param {Object} context
  * @param {{code: String, details: String?}} context.reason
  * @returns {Promise<DBOperatorRecord>}
@@ -216,7 +216,7 @@ async function deleteSingleFeature ({ featureId, user, record }, { reason }) {
 /**
  * @param {Object} recordInfo
  * @param {CartoBioUser} recordInfo.user
- * @param {DBOperatorRecord} recordInfo.record
+ * @param {NormalizedRecord} recordInfo.record
  * @param {CartoBioFeature} feature
  * @returns {Promise<DBOperatorRecord>}
  */
@@ -282,7 +282,7 @@ async function getRecord (recordId) {
 }
 
 /**
- * @param {{user: CartoBioUser, record: DBOperatorRecord}} recordInfo
+ * @param {{user: CartoBioUser, record: NormalizedRecord}} recordInfo
  * @return {Promise<DBOperatorRecord>}
  */
 async function deleteRecord ({ user, record }) {
@@ -364,7 +364,7 @@ async function fetchLatestCustomersByControlBody ({ ocId }) {
 /**
  * @param {Object} recordInfo
  * @param {CartoBioUser} recordInfo.user
- * @param {DBOperatorRecord} recordInfo.record
+ * @param {NormalizedRecord} recordInfo.record
  * @param {Object} patch
  * @param {String} patch.auditeur_notes
  * @param {String} patch.audit_notes


### PR DESCRIPTION
De fait on utilise NormalizedRecord partout vu que quand on l'attache à la requête on le normalise avant.