### PR TITLE
Prebuild geodata dans Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY ./bin ./bin
 COPY ./data ./data
 
 RUN npm ci --build-from-source --shared_gdal
+RUN npm run build:geo-data
 
 
 # Bundle app source


### PR DESCRIPTION
Pour démarrer plus vite tout en évitant de faire du build des geodata un pré-requis de l'installation du paquet.