### PR TITLE
Retourne une version simplifiée des adresses opérateurs

### DIFF
--- a/lib/outputs/operator.js
+++ b/lib/outputs/operator.js
@@ -101,6 +101,7 @@ function normalizeOperator (operator) {
     certificats,
     datePremierEngagement,
     organismeCertificateur,
+    adressesOperateurs: adressesOperateurs.filter(({ active }) => active).map(({ lat, long, codeCommune }) => ({ lat, long, codeCommune })),
     codeCommune: adressesOperateurs[0]?.codeCommune ?? null,
     departement: adressesOperateurs[0]?.codeCommune?.slice(0, -3) ?? null,
     commune: adressesOperateurs[0]?.ville ?? null,

--- a/lib/outputs/operator.test.js
+++ b/lib/outputs/operator.test.js
@@ -26,6 +26,22 @@ const baseOperator = {
       date: '2023-02-28'
     }
   ],
+  adressesOperateurs: [
+    {
+      active: true,
+      lat: 45.470757,
+      long: 4.63488839,
+      codeCommune: '42210',
+      ville: 'Sainte-Croix-en-Jarez'
+    },
+    {
+      active: false,
+      lat: 45.47151,
+      long: 4.5885,
+      codeCommune: '42271',
+      ville: 'Saint-Paul-en-Jarez'
+    }
+  ],
   notifications: [
     {
       id: 1,
@@ -46,9 +62,16 @@ describe('normalizeOperator()', () => {
     expect(normalizeOperator(operator)).toMatchObject({
       id: 1,
       numeroBio: '34857',
-      codeCommune: null,
+      codeCommune: '42210',
       numeroPacage: null,
-      organismeCertificateur: { id: 999, nom: 'CartoBiOC' }
+      organismeCertificateur: { id: 999, nom: 'CartoBiOC' },
+      adressesOperateurs: [
+        {
+          lat: 45.470757,
+          long: 4.63488839,
+          codeCommune: '42210'
+        }
+      ]
     })
   })
 
@@ -58,9 +81,16 @@ describe('normalizeOperator()', () => {
     expect(normalizeOperator(operator)).toMatchObject({
       id: 1,
       numeroBio: '34857',
-      codeCommune: null,
+      codeCommune: '42210',
       numeroPacage: null,
-      organismeCertificateur: { id: 999, nom: 'CartoBiOC' }
+      organismeCertificateur: { id: 999, nom: 'CartoBiOC' },
+      adressesOperateurs: [
+        {
+          lat: 45.470757,
+          long: 4.63488839,
+          codeCommune: '42210'
+        }
+      ]
     })
   })
 
@@ -70,9 +100,16 @@ describe('normalizeOperator()', () => {
     expect(normalizeOperator(operator)).toMatchObject({
       id: 1,
       numeroBio: '34857',
-      codeCommune: null,
+      codeCommune: '42210',
       numeroPacage: null,
-      organismeCertificateur: {}
+      organismeCertificateur: {},
+      adressesOperateurs: [
+        {
+          lat: 45.470757,
+          long: 4.63488839,
+          codeCommune: '42210'
+        }
+      ]
     })
   })
 
@@ -80,9 +117,16 @@ describe('normalizeOperator()', () => {
     expect(normalizeOperator({ ...baseOperator, certificats: null, notifications: null })).toMatchObject({
       id: 1,
       numeroBio: '34857',
-      codeCommune: null,
+      codeCommune: '42210',
       numeroPacage: null,
-      organismeCertificateur: {}
+      organismeCertificateur: {},
+      adressesOperateurs: [
+        {
+          lat: 45.470757,
+          long: 4.63488839,
+          codeCommune: '42210'
+        }
+      ]
     })
   })
 })

--- a/lib/outputs/types/operator.d.ts
+++ b/lib/outputs/types/operator.d.ts
@@ -1,4 +1,4 @@
-import {OrganismeCertificateur} from "../../providers/types/agence-bio";
+import {AgenceBioAdresseGeo, OrganismeCertificateur} from "../../providers/types/agence-bio";
 import {NormalizedRecord} from "./record";
 
 export type AgenceBioNormalizedOperator = {
@@ -13,6 +13,7 @@ export type AgenceBioNormalizedOperator = {
     datePremierEngagement: Date;
     certificats: any[];
     organismeCertificateur: OrganismeCertificateur | {};
+    adressesOperateurs: AgenceBioAdresseGeo[],
     codeCommune: string;
     departement: string;
     commune: string;

--- a/lib/providers/types/agence-bio.d.ts
+++ b/lib/providers/types/agence-bio.d.ts
@@ -39,7 +39,7 @@ export type AgenceBioOperator = {
     sitesWeb: string[];
     notifications?: AgenceBioNotification[] | undefined;
     certificats?: AgenceBioCertificate[] | undefined;
-    adressesOperateurs?: AgenceBioAdresses | undefined;
+    adressesOperateurs?: AgenceBioAdresses[];
 };
 export type AgenceBioCertificate = {
     organisme: string;
@@ -78,17 +78,31 @@ export type AgenceBioNotification = {
     activites: AgenceBioActivity[];
     productions: AgenceBioProduction[];
 };
-export type AgenceBioAdresses = {
-    lieu: string;
-    dates: string;
-    codePostal: string;
-    ville: string;
+
+/**
+ * This is what we output
+ */
+export type AgenceBioAdresseGeo = {
+  codeCommune: string,
+  lat: number,
+  long: number,
+}
+
+/**
+ * This is what we consume
+ */
+export type AgenceBioAdresses = AgenceBioAdresseGeo & {
+  active: boolean;
+  lieu: string;
+  dates: string;
+  codePostal: string;
+  ville: string
 };
 /**
  * Only some endpoints provide this data
  */
 export type AgenceBioOperatorWithAdresses = AgenceBioOperator & {
-    adressesOperateurs: AgenceBioAdresses;
+    adressesOperateurs: AgenceBioAdresses[];
 };
 export type AgenceBioActivity = {
     id: number;


### PR DESCRIPTION
Permet de géolocaliser côté front, et peut-être à terme de proposer des villes par défaut lors de l'ajout de parcelles.

Va avec AgenceBio/cartobio-front#314