### PR TITLE
Migration vers Postgres 15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     - external
 
   db:
-    image: kartoza/postgis:14-3.3
+    image: kartoza/postgis:15-3.4
     volumes:
       - geo-db-data:/var/lib/postgresql
     restart: on-failure


### PR DESCRIPTION
Sous Postgres 14, pour le backup : 

```sh
docker compose exec db pg_dumpall -U docker -h 0.0.0.0 -W -l gis > backup.sql
```

Après avoir checkouté cette branche, pour restaurer les données : 

```sh
docker compose run -v $(pwd)/backup.sql:/docker-entrypoint-initdb.d/setup-db.sql db
```

Puis pour virer les données de PG 14 : 

```sh
docker compose exec db rm -rf /var/lib/postgresql/14
```

Ensuite en démarrant la base comme d'hab, l'app se connecte.

