### PR TITLE
Édition hors-ligne et synchronisation

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -10,6 +10,7 @@ const InvalidRequestApiError = createError('INVALID_API_REQUEST', '%s', 400)
 const NotFoundApiError = createError('NOT_FOUND', '%s', 404)
 const UnauthorizedApiError = createError('UNAUTHORIZED', 'Accès refusé : %s', 401)
 const BadGatewayApiError = createError('BAD_GATEWAY', 'Erreur serveur : %s', 502)
+const PreconditionFailedApiError = createError('PRECONDITION_FAILED', 'La ressource a été modifiée depuis la dernière requête.', 412)
 
 const isHandledError = (error) => {
   const { statusCode } = error
@@ -59,6 +60,7 @@ module.exports = {
   NotFoundApiError,
   UnauthorizedApiError,
   BadGatewayApiError,
+  PreconditionFailedApiError,
   isHandledError,
   errorHandler
 }

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -8,7 +8,7 @@ const { version: apiVersion } = require('../package.json')
 const { checkOcToken } = require('./providers/agence-bio.js')
 const { ExpiredCredentialsApiError, InvalidCredentialsApiError, NotFoundApiError, UnauthorizedApiError } = require('./errors.js')
 const { fetchOperatorByNumeroBio } = require('./providers/agence-bio')
-const { BadGatewayApiError } = require('./errors')
+const { BadGatewayApiError, PreconditionFailedApiError } = require('./errors')
 /**
  * @typedef {import('fast-jwt').TokenValidationErrorCode} TokenValidationErrorCode
  * @typedef {import('fastify').FastifyRequest} FastifyRequest
@@ -175,6 +175,11 @@ function enforceRecord ({ queryFn, param }) {
 
     if (!record) {
       throw new NotFoundApiError('Parcellaire introuvable')
+    }
+
+    if (request.headers['if-unmodified-since'] && new Date(request.headers['if-unmodified-since']).getTime() < record.updated_at) {
+      console.log(request.headers['if-unmodified-since'], record.updated_at)
+      throw new PreconditionFailedApiError('Le contenu a été modifié depuis votre dernière requête.')
     }
 
     // Finally, assign the fetched record to forthcoming hooks

--- a/lib/middlewares.test.js
+++ b/lib/middlewares.test.js
@@ -26,6 +26,7 @@ describe('enforceRecord()', () => {
   test('known operator and known record', async () => {
     const request = {
       params: { recordId: '054f0d70-c3da-448f-823e-81fcf7c2bf6e' },
+      headers: {},
       record: null
     }
 

--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -363,24 +363,7 @@ async function patchFeatureCollection ({ user, record }, features) {
       [record.record_id, historyEntry])
 
     for (const feature of features) {
-      const sqlArgs = [
-        /* $1 */ record.record_id,
-        /* $2 */ feature.id || getRandomFeatureId(),
-        /* $3 */ feature.geometry,
-        /* $4 */ feature.properties.COMMUNE,
-        /* $5 */ feature.properties.cultures ? JSON.stringify(feature.properties.cultures) : null,
-        /* $6 */ feature.properties.conversion_niveau,
-        /* $7 */ feature.properties.engagement_date,
-        /* $8 */ feature.properties.commentaires,
-        /* $9 */ feature.properties.auditeur_notes,
-        /* $10 */ feature.properties.annotations ? JSON.stringify(feature.properties.annotations) : null,
-        /* $11 */ feature.properties.NOM,
-        /* $12 */ feature.properties.PACAGE,
-        /* $13 */ feature.properties.NUMERO_I,
-        /* $14 */ feature.properties.NUMERO_P,
-        /* $15 */ feature.properties.cadastre
-      ]
-      const { rows } = await client.query(
+      await client.query(
         /* sql */`
           UPDATE cartobio_parcelles
           SET (geometry, commune, cultures, conversion_niveau, engagement_date, commentaire, auditeur_notes,
@@ -400,20 +383,24 @@ async function patchFeatureCollection ({ user, record }, features) {
           WHERE record_id = $1
             AND id = $2
           RETURNING record_id, id`,
-        sqlArgs
+        [
+          /* $1 */ record.record_id,
+          /* $2 */ feature.id || getRandomFeatureId(),
+          /* $3 */ feature.geometry,
+          /* $4 */ feature.properties.COMMUNE,
+          /* $5 */ feature.properties.cultures ? JSON.stringify(feature.properties.cultures) : null,
+          /* $6 */ feature.properties.conversion_niveau,
+          /* $7 */ feature.properties.engagement_date,
+          /* $8 */ feature.properties.commentaires,
+          /* $9 */ feature.properties.auditeur_notes,
+          /* $10 */ feature.properties.annotations ? JSON.stringify(feature.properties.annotations) : null,
+          /* $11 */ feature.properties.NOM,
+          /* $12 */ feature.properties.PACAGE,
+          /* $13 */ feature.properties.NUMERO_I,
+          /* $14 */ feature.properties.NUMERO_P,
+          /* $15 */ feature.properties.cadastre
+        ]
       )
-
-      if (!rows.length) {
-        await client.query(
-          /* sql */`
-            INSERT INTO cartobio_parcelles
-            (record_id, id, geometry, commune, cultures, conversion_niveau, engagement_date, commentaire, auditeur_notes,
-             annotations, created, updated, name, numero_pacage, numero_ilot_pac, numero_parcelle_pac,
-             reference_cadastre)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, now(), now(), $11, $12, $13, $14, $15)`,
-          sqlArgs
-        )
-      }
     }
     await client.query('COMMIT;')
     return joinRecordParcelles(updatedRows.at(0))

--- a/test/utils.js
+++ b/test/utils.js
@@ -10,8 +10,8 @@ module.exports.loadRecordFixture = async function () {
         INSERT INTO cartobio_operators
         (record_id, version_name, numerobio, certification_state, certification_date_debut,
          certification_date_fin, audit_date, audit_notes, audit_demandes, audit_history, metadata, oc_id,
-         oc_label)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12, $13)
+         oc_label, updated_at, created_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12, $13, now(), now())
       `,
       [
       /*  $1 */ record.record_id,


### PR DESCRIPTION
Léger changements sur l'API qui vont de paire avec https://github.com/AgenceBio/cartobio-front/pull/365 :
* mises à jour de documentation obsolètes depuis le passage à la table parcellaire
* gestion du header `If-Unmodified-Since`