### PR TITLE
fix: corrige la recuperation des parcellaires

### DIFF
--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -199,6 +199,7 @@ async function createOrUpdateOperatorRecord (record, context = {}, customClient)
                     ST_ReducePrecision(ST_MakeValid(ST_SetSRID($3::geometry, 4326)), 0.00001)
                 )
                 AND cartobio_operators.record_id != $1
+                AND cartobio_operators.deleted_at IS NULL
                 AND $17
               ORDER BY created_at DESC
               LIMIT 1


### PR DESCRIPTION
- Verifie que le parcellaire utilisé comme dernière version n'a pas été supprimé