### PR TITLE
chore: enregistre plus d'info en metadata

### DIFF
--- a/lib/providers/__fixtures__/agence-bio-api-parcellaire.json
+++ b/lib/providers/__fixtures__/agence-bio-api-parcellaire.json
@@ -112,7 +112,6 @@
   "anneeReferenceControle": 2023,
   "dateCertificationDebut": "2023-01-01",
   "dateCertificationFin": "2025-03-31",
-  "anneeAssolement": 2023,
   "dateAudit": "2023-06-23",
   "numeroPacage": 70015772,
   "parcelles": [

--- a/lib/providers/__fixtures__/agence-bio-api-parcellaire.json
+++ b/lib/providers/__fixtures__/agence-bio-api-parcellaire.json
@@ -160,7 +160,6 @@
     "numeroBio": "88888",
     "numeroClient": "100012",
     "anneeReferenceControle": 2022,
-    "anneeAssolement": 2022,
     "dateAudit": "2023-04-27",
     "dateCertificationDebut": null,
     "dateCertificationFin": null,

--- a/lib/providers/__fixtures__/agence-bio-api-parcellaire_another_expectation.json
+++ b/lib/providers/__fixtures__/agence-bio-api-parcellaire_another_expectation.json
@@ -1,0 +1,45 @@
+{
+  "record": {
+    "numerobio": "172301",
+    "certification_state": "CERTIFIED",
+    "oc_id": 1,
+    "oc_label": "Ecocert France",
+    "parcelles": {
+      "type": "FeatureCollection",
+      "features": 
+      [
+        {
+          "type": "Feature",
+          "id": 124300,
+          "properties": {
+            "id": 124300,
+            "cultures": 
+            [
+              {
+                "CPF": "",
+                "date_semis": "",
+                "surface": null,
+                "variete": ""
+              }
+            ],
+            "NUMERO_I": "309",
+            "NUMERO_P": "1",
+            "PACAGE": "32165694",
+            "conversion_niveau": "C1",
+            "engagement_date": "2022-08-17",
+            "auditeur_notes": null
+          },
+          "geometry": null
+        }
+      ]
+    },
+    "certification_date_debut": "2023-01-01",
+    "certification_date_fin": "2025-03-31",
+    "audit_date": "2023-03-30T00:00:00.000Z",
+    "metadata": {
+      "source": "API Parcellaire",
+      "anneeReferenceControle": 2023,
+      "anneeAssolement": 2023
+    }
+  }
+}

--- a/lib/providers/__fixtures__/agence-bio-api-parcellaire_expectation.json
+++ b/lib/providers/__fixtures__/agence-bio-api-parcellaire_expectation.json
@@ -229,6 +229,11 @@
           }
         }
       ]
+    },
+    "metadata": {
+      "anneeAssolement": 2022,
+      "anneeReferenceControle": 2022,
+      "source": "API Parcellaire"
     }
   }
 }

--- a/lib/providers/__fixtures__/agence-bio-api-parcellaire_expectation_without_assolement.json
+++ b/lib/providers/__fixtures__/agence-bio-api-parcellaire_expectation_without_assolement.json
@@ -1,0 +1,70 @@
+{
+  "record": {
+    "numerobio": "88888",
+    "certification_state": "CERTIFIED",
+    "oc_id": 1,
+    "oc_label": "Ecocert France",
+    "parcelles": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "id": 45742,
+          "properties": {
+            "id": 45742,
+            "cultures": [
+              {
+                "CPF": "01.92",
+                "date_semis": "2023-10-10",
+                "surface": 25,
+                "unit": "%",
+                "variete": ""
+              }
+            ],
+            "NUMERO_I": "12",
+            "NUMERO_P": "5",
+            "PACAGE": "084012821",
+            "conversion_niveau": "AB",
+            "engagement_date": "2023-04-27",
+            "auditeur_notes": "Parcelle 5 ILOT 12 PAC 2023 0C 1271"
+          },
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  4.874099084318204,
+                  44.255949709765304
+                ],
+                [
+                  4.873961402930124,
+                  44.255016135661734
+                ],
+                [
+                  4.873653226374768,
+                  44.25500184845603
+                ],
+                [
+                  4.873800472836859,
+                  44.255928756333255
+                ],
+                [
+                  4.874099084318204,
+                  44.255949709765304
+                ]
+              ]
+            ]
+          }
+        }
+      ]
+    },
+    "audit_notes": "notes d'audit",
+    "certification_date_debut": null,
+    "certification_date_fin": null,
+    "audit_date": "2023-04-27T00:00:00.000Z",
+    "metadata": {
+      "source": "API Parcellaire",
+      "anneeReferenceControle": 2022
+    }
+  }
+}

--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -1228,7 +1228,9 @@ async function * parseAPIParcellaireStream (stream, { organismeCertificateur }) 
         audit_date: (new Date(record.dateAudit)).toISOString(),
         metadata: {
           source: 'API Parcellaire',
-          sourceLastUpdate: new Date().toISOString()
+          sourceLastUpdate: new Date().toISOString(),
+          anneeReferenceControle: record.anneeReferenceControle,
+          ...(record.anneeAssolement ? { anneeAssolement: record.anneeAssolement } : {})
         }
       }
     }

--- a/lib/providers/cartobio.js
+++ b/lib/providers/cartobio.js
@@ -1230,7 +1230,7 @@ async function * parseAPIParcellaireStream (stream, { organismeCertificateur }) 
           source: 'API Parcellaire',
           sourceLastUpdate: new Date().toISOString(),
           anneeReferenceControle: record.anneeReferenceControle,
-          ...(record.anneeAssolement ? { anneeAssolement: record.anneeAssolement } : {})
+          anneeAssolement: record.anneeAssolement
         }
       }
     }

--- a/lib/providers/cartobio.test.js
+++ b/lib/providers/cartobio.test.js
@@ -168,10 +168,12 @@ describe('evvParcelles', () => {
 
 describe('parseAPIParcellaireStream', () => {
   test('turns a file into a working GeoJSON', async () => {
-    expect.assertions(3)
+    expect.assertions(5)
 
     // @ts-ignore
     const expectation = require('./__fixtures__/agence-bio-api-parcellaire_expectation.json')
+    // @ts-ignore
+    const anotherExpectation = require('./__fixtures__/agence-bio-api-parcellaire_another_expectation.json')
     const fixtureFile = createReadStream(join(__dirname, '__fixtures__', 'agence-bio-api-parcellaire.json'))
     const organismeCertificateur = { id: 1, nom: 'Ecocert France' }
 
@@ -188,5 +190,11 @@ describe('parseAPIParcellaireStream', () => {
         error: new Error('champ geom incorrect : Expected \',\' or \']\' after array element in JSON at position 32635')
       }
     })
+
+    const { value: anotherResult } = await generator.next()
+
+    const parsedResult = JSON.parse(JSON.stringify(anotherResult))
+    expect(parsedResult).toMatchObject(anotherExpectation)
+    expect('anneeAssolement' in parsedResult).toEqual(false)
   })
 })

--- a/lib/providers/cartobio.test.js
+++ b/lib/providers/cartobio.test.js
@@ -168,12 +168,13 @@ describe('evvParcelles', () => {
 
 describe('parseAPIParcellaireStream', () => {
   test('turns a file into a working GeoJSON', async () => {
-    expect.assertions(5)
+    expect.assertions(9)
 
     // @ts-ignore
     const expectation = require('./__fixtures__/agence-bio-api-parcellaire_expectation.json')
     // @ts-ignore
     const anotherExpectation = require('./__fixtures__/agence-bio-api-parcellaire_another_expectation.json')
+    const expectationWithoutAssolement = require('./__fixtures__/agence-bio-api-parcellaire_expectation_without_assolement.json')
     const fixtureFile = createReadStream(join(__dirname, '__fixtures__', 'agence-bio-api-parcellaire.json'))
     const organismeCertificateur = { id: 1, nom: 'Ecocert France' }
 
@@ -195,6 +196,15 @@ describe('parseAPIParcellaireStream', () => {
 
     const parsedResult = JSON.parse(JSON.stringify(anotherResult))
     expect(parsedResult).toMatchObject(anotherExpectation)
-    expect('anneeAssolement' in parsedResult).toEqual(false)
+    expect('anneeReferenceControle' in parsedResult.record.metadata).toEqual(true)
+    expect('anneeAssolement' in parsedResult.record.metadata).toEqual(true)
+
+    const { value: resultWithoutAssolement } = await generator.next()
+
+    const parsedResultWithoutAssolement = JSON.parse(JSON.stringify(resultWithoutAssolement))
+    console.log(JSON.stringify(resultWithoutAssolement))
+    expect(parsedResultWithoutAssolement).toMatchObject(expectationWithoutAssolement)
+    expect('anneeReferenceControle' in parsedResult.record.metadata).toEqual(true)
+    expect('anneeAssolement' in parsedResult.record.metadata).toEqual(true)
   })
 })


### PR DESCRIPTION
Ajoute 2 infos dans le champs metadata lors de l'import via l'api parcellaire